### PR TITLE
Prometheus grafana

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,3 +18,17 @@ services:
     restart: on-failure
     ports:
       - 8081:8080
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+
+
+  grafana:
+    image: grafana/grafana:4.5.2
+    ports:
+      - "3000:3000"

--- a/itu-minitwit-go/go.mod
+++ b/itu-minitwit-go/go.mod
@@ -9,4 +9,5 @@ require (
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 	gorm.io/driver/sqlite v1.1.4
 	gorm.io/gorm v1.20.12
+	github.com/prometheus/client_golang v1.9.0 
 )

--- a/itu-minitwit-go/minitwit.go
+++ b/itu-minitwit-go/minitwit.go
@@ -9,6 +9,8 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 func initDb(driver string, datasource string) (*gorm.DB, error) {
@@ -22,12 +24,22 @@ func initDb(driver string, datasource string) (*gorm.DB, error) {
 	return db, sql.Ping()
 }
 
+
+
+
+func init() {
+	prometheus.MustRegister(minitwit_http_responses_total)
+}
+
 func main() {
+
+
 	gorm, err := initDb(DRIVER, DATABASE)
 	// sql, _ := gorm.DB()
 	if err != nil {
 		log.Fatal(err)
 	}
+
 
 	LoadTemplates()
 
@@ -45,9 +57,12 @@ func main() {
 	r.Handle("/logout", LogoutHandler(store, gorm)).Methods("GET")
 	r.Handle("/add_message", AddMessageHandler(store, gorm)).Methods("POST")
 	r.Handle("/personaltimeline", PersonalTimeline(store, gorm)).Methods("GET", "POST")
+	r.Handle("/metrics",promhttp.Handler())
 	r.Handle("/{username}", UserTimeline(store, gorm)).Methods("GET")
 	r.Handle("/{username}/follow", FollowUserHandler(store, gorm)).Methods("GET")
 	r.Handle("/{username}/unfollow", UnfollowUserHandler(store, gorm)).Methods("GET")
+
+
 	// r.Handle("/user/{id}", GetUserByIdHandler(gorm)).Methods("GET")
 
 	http.ListenAndServe(":8080", r)

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,29 @@
+global:
+  scrape_interval:     15s # By default, scrape targets every 15 seconds.
+  evaluation_interval: 15s # Evaluate rules every 15 seconds.
+
+  # Attach these extra labels to all timeseries collected by this Prometheus instance.
+  external_labels:
+    monitor: 'codelab-monitor'
+
+rule_files:
+  - 'prometheus.rules.yml'
+
+scrape_configs:
+  - job_name: 'prometheus'
+
+    # Override the global default and scrape targets from this job every 5 seconds.
+    scrape_interval: 5s
+
+    static_configs:
+      - targets: ['prometheus:9090']
+
+  - job_name:       'itu-minitwit-app'
+
+    # Override the global default and scrape targets from this job every 5 seconds.
+    scrape_interval: 5s
+
+    static_configs:
+      - targets: ['minitwit:8080']
+        labels:
+          group: 'production'


### PR DESCRIPTION
Added monitoring with Prometheus and Grafana.
Currently only monitoring number of http responses, but it is easy to add more metrics