### PR TITLE
Prometheus grafana major upgrade

### DIFF
--- a/itu-minitwit-api/minitwit-api.go
+++ b/itu-minitwit-api/minitwit-api.go
@@ -11,6 +11,8 @@ import (
 	"github.com/joho/godotenv"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 const DRIVER = "sqlite3"
@@ -62,9 +64,19 @@ func ReadDVariables() (string, error) {
 }
 
 
+// Initialize prometheus
+func init() {
+	prometheus.MustRegister(minitwit_api_register_requests)
+	prometheus.MustRegister(minitwit_api_messages_requests)
+	prometheus.MustRegister(minitwit_api_messages_per_user_requests)
+	prometheus.MustRegister(minitwit_api_follow_requests)
+	prometheus.MustRegister(minitwit_api_total_requests)
+}
 
 
 func main() {
+
+
 	err := godotenv.Load("../.env")
 	if err != nil {
 		log.Println("Failed to read .env file")
@@ -82,11 +94,13 @@ func main() {
 	}
 
 	r := mux.NewRouter()
+
 	r.Use(LatestMiddleware(gorm))
 	r.Use(AuthenticationMiddleware())
 	r.Handle("/latest", LatestHandler(gorm)).Methods("GET")
 	r.Handle("/register", RegisterApiHandler(gorm)).Methods("POST")
 	r.Handle("/msgs", MessagesHandler(gorm)).Methods("GET")
+	r.Handle("/metrics",promhttp.Handler())
 	r.Handle("/msgs/{username}", MessagesPerUserHandler(gorm)).Methods("GET", "POST")
 	r.Handle("/fllws/{username}", FollowHandler(gorm)).Methods("GET", "POST")
 

--- a/itu-minitwit-go/handlers.go
+++ b/itu-minitwit-go/handlers.go
@@ -13,7 +13,6 @@ import (
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
 	"github.com/prometheus/client_golang/prometheus"
-	// "github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 const DRIVER = "sqlite3"
@@ -22,10 +21,46 @@ const PER_PAGE = 30
 const DEBUG = true
 const SECRET_KEY = "development key"
 
-//Prometheus metrics
+// Prometheus metrics
 var (
-	minitwit_ui_http_requests = prometheus.NewCounter(prometheus.CounterOpts{
-		Name:        "minitwit_ui_http_requests_total",
+	minitwit_ui_usertimeline_requests = prometheus.NewCounter(prometheus.CounterOpts{
+		Name:        "minitwit_ui_usertimeline_requests",
+		Help:        "The count of HTTP requests to the /{username} endpoint of the frontend API.",
+	})
+	minitwit_ui_personaltimeline_requests = prometheus.NewCounter(prometheus.CounterOpts{
+		Name:        "minitwit_ui_personaltimeline_requests",
+		Help:        "The count of HTTP requests to the /personaltimeline endpoint of the frontend API.",
+	})
+	minitwit_ui_unfollow_requests = prometheus.NewCounter(prometheus.CounterOpts{
+		Name:        "minitwit_ui_unfollow_requests",
+		Help:        "The count of HTTP requests to the /{username}/unfollow endpoint of the frontend API.",
+	})
+	minitwit_ui_follow_requests = prometheus.NewCounter(prometheus.CounterOpts{
+		Name:        "minitwit_ui_follow_requests",
+		Help:        "The count of HTTP requests to the /{username}/follow endpoint of the frontend API.",
+	})
+	minitwit_ui_addmessage_requests = prometheus.NewCounter(prometheus.CounterOpts{
+		Name:        "minitwit_ui_addmessage_requests",
+		Help:        "The count of HTTP requests to the /add_message endpoint of the frontend API.",
+	})
+	minitwit_ui_homepage_requests = prometheus.NewCounter(prometheus.CounterOpts{
+		Name:        "minitwit_ui_homepage_requests",
+		Help:        "The count of HTTP requests to the / (home) endpoint of the frontend API.",
+	})
+	minitwit_ui_register_requests = prometheus.NewCounter(prometheus.CounterOpts{
+		Name:        "minitwit_ui_register_requests",
+		Help:        "The count of HTTP requests to the /register endpoint of the frontend API.",
+	})
+	minitwit_ui_login_requests = prometheus.NewCounter(prometheus.CounterOpts{
+		Name:        "minitwit_ui_login_requests",
+		Help:        "The count of HTTP requests to the /login endpoint of the frontend API.",
+	})
+	minitwit_ui_logout_requests = prometheus.NewCounter(prometheus.CounterOpts{
+		Name:        "minitwit_ui_logout_requests",
+		Help:        "The count of HTTP requests to the /logout endpoint of the frontend API.",
+	})
+	minitwit_ui_total_requests = prometheus.NewCounter(prometheus.CounterOpts{
+		Name:        "minitwit_ui_total_requests",
 		Help:        "The count of HTTP requests to the frontend API.",
 	})
 )
@@ -46,6 +81,7 @@ func LoadTemplates() {
 //LoginHandler ...
 func LoginHandler(store *sessions.CookieStore, db *gorm.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		minitwit_ui_login_requests.Inc()
 		session, _ := store.Get(r, "session_cookie")
 
 		userId := session.Values["user_id"]
@@ -93,6 +129,7 @@ func LoginHandler(store *sessions.CookieStore, db *gorm.DB) http.Handler {
 
 func LogoutHandler(store *sessions.CookieStore, db *gorm.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		minitwit_ui_logout_requests.Inc()
 		session, _ := store.Get(r, "session_cookie")
 		session.Values["user_id"] = nil
 		session.AddFlash("You were logged out")
@@ -109,6 +146,7 @@ func LogoutHandler(store *sessions.CookieStore, db *gorm.DB) http.Handler {
 
 func RegisterHandler(store *sessions.CookieStore, db *gorm.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		minitwit_ui_register_requests.Inc()
 		session, _ := store.Get(r, "session_cookie")
 		userId := session.Values["user_id"]
 		isLoggedIn := userId != "" && userId != nil
@@ -201,6 +239,7 @@ func RegisterHandler(store *sessions.CookieStore, db *gorm.DB) http.Handler {
 
 func HomeHandler(store *sessions.CookieStore, db *gorm.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		minitwit_ui_homepage_requests.Inc()
 		session, _ := store.Get(r, "session_cookie")
 
 		userId := session.Values["user_id"]
@@ -220,6 +259,8 @@ func HomeHandler(store *sessions.CookieStore, db *gorm.DB) http.Handler {
 
 func AddMessageHandler(store *sessions.CookieStore, db *gorm.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		minitwit_ui_addmessage_requests.Inc()
 
 		session, _ := store.Get(r, "session_cookie")
 		userId := session.Values["user_id"]
@@ -247,7 +288,7 @@ func BeforeRequestMiddleware(store *sessions.CookieStore, db *gorm.DB) func(http
 		mdfn := func(w http.ResponseWriter, r *http.Request) {
 
 			//Increment number of http requests in Prometheus
-			minitwit_ui_http_requests.Inc()
+			minitwit_ui_total_requests.Inc()
 
 			session, _ := store.Get(r, "session_cookie")
 			userId := session.Values["user_id"]
@@ -275,6 +316,8 @@ func BeforeRequestMiddleware(store *sessions.CookieStore, db *gorm.DB) func(http
 
 func FollowUserHandler(store *sessions.CookieStore, db *gorm.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		minitwit_ui_follow_requests.Inc()
 
 		session, _ := store.Get(r, "session_cookie")
 		userId := session.Values["user_id"]
@@ -310,6 +353,8 @@ func FollowUserHandler(store *sessions.CookieStore, db *gorm.DB) http.Handler {
 func UnfollowUserHandler(store *sessions.CookieStore, db *gorm.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
+		minitwit_ui_unfollow_requests.Inc()
+
 		session, _ := store.Get(r, "session_cookie")
 		userId := session.Values["user_id"]
 		if userId == nil {
@@ -342,6 +387,9 @@ func UnfollowUserHandler(store *sessions.CookieStore, db *gorm.DB) http.Handler 
 
 func PersonalTimeline(store *sessions.CookieStore, db *gorm.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		minitwit_ui_personaltimeline_requests.Inc()
+
 		session, _ := store.Get(r, "session_cookie")
 		userId := session.Values["user_id"]
 		isLoggedIn := userId != "" && userId != nil
@@ -428,6 +476,9 @@ func PersonalTimeline(store *sessions.CookieStore, db *gorm.DB) http.Handler {
 
 func UserTimeline(store *sessions.CookieStore, db *gorm.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		minitwit_ui_usertimeline_requests.Inc()
+
 		session, _ := store.Get(r, "session_cookie")
 		userId := session.Values["user_id"]
 		isLoggedIn := userId != "" && userId != nil

--- a/itu-minitwit-go/minitwit.go
+++ b/itu-minitwit-go/minitwit.go
@@ -61,8 +61,19 @@ return fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%s sslmode=disabl
 
 //Initialize prometheus
 func init() {
-	prometheus.MustRegister(minitwit_ui_http_requests)
+	prometheus.MustRegister(minitwit_ui_total_requests)
+	prometheus.MustRegister(minitwit_ui_login_requests)
+	prometheus.MustRegister(minitwit_ui_logout_requests)
+	prometheus.MustRegister(minitwit_ui_register_requests)
+	prometheus.MustRegister(minitwit_ui_homepage_requests)
+	prometheus.MustRegister(minitwit_ui_addmessage_requests)
+	prometheus.MustRegister(minitwit_ui_follow_requests)
+	prometheus.MustRegister(minitwit_ui_unfollow_requests)
+	prometheus.MustRegister(minitwit_ui_personaltimeline_requests)
+	prometheus.MustRegister(minitwit_ui_usertimeline_requests)
 }
+
+
 
 func main() {
 	err := godotenv.Load("../.env")

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -24,6 +24,6 @@ scrape_configs:
     scrape_interval: 5s
 
     static_configs:
-      - targets: ['minitwit:8080]
+      - targets: ['minitwit:8080']
         labels:
           group: 'production'

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -10,6 +10,8 @@ rule_files:
   - 'prometheus.rules.yml'
 
 scrape_configs:
+
+
   - job_name: 'prometheus'
 
     # Override the global default and scrape targets from this job every 5 seconds.
@@ -18,12 +20,22 @@ scrape_configs:
     static_configs:
       - targets: ['prometheus:9090']
 
-  - job_name:       'itu-minitwit-app'
+  - job_name: 'minitwit-api'
+
+    # Override the global default and scrape targets from this job every 5 seconds.
+    scrape_interval: 5s
+
+    static_configs:
+      - targets: ['minitwit-api:8080']
+
+    basic_auth:
+      username: 'simulator'
+      password: 'super_safe!'
+
+  - job_name: 'minitwit'
 
     # Override the global default and scrape targets from this job every 5 seconds.
     scrape_interval: 5s
 
     static_configs:
       - targets: ['minitwit:8080']
-        labels:
-          group: 'production'


### PR DESCRIPTION
Finally got Prometheus to work properly with both the frontend and backend API. Additionally, Prometheus now skips the Latest middleware check so our log will not be filled with complaints about not providing a latest value

The following metrics were added:

- minitwit_ui_usertimeline_requests
- minitwit_ui_personaltimeline_requests
- minitwit_ui_unfollow_requests
- minitwit_ui_follow_requests
- minitwit_ui_addmessage_requests
- minitwit_ui_homepage_requests
- minitwit_ui_register_requests
- minitwit_ui_login_requests
- minitwit_ui_logout_requests
- minitwit_ui_total_requests
- minitwit_api_register_requests
- minitwit_api_messages_requests
- minitwit_api_messages_per_user_requests
- minitwit_api_follow_requests
- minitwit_api_total_requests