### PR TITLE
Now measures function execution speed and Grafana dashboards should be able to persist between deploys

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -40,3 +40,8 @@ services:
     image: grafana/grafana:4.5.2
     ports:
       - "3000:3000"
+    volumes:
+      - grafana-storage:/var/lib/grafana
+
+volumes:
+  grafana-storage:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,8 @@ services:
     image: grafana/grafana:4.5.2
     ports:
       - "3000:3000"
+    volumes:
+      - grafana-storage:/var/lib/grafana
 
   database:
     image: 'postgres'
@@ -65,3 +67,4 @@ services:
 
 volumes:
   database-data:
+  grafana-storage:

--- a/itu-minitwit-api/handlers.go
+++ b/itu-minitwit-api/handlers.go
@@ -37,20 +37,62 @@ var (
 		Name:				 "minitwit_api_total_requests",
 		Help:				 "The total count of requests to the backend API",
 	})
+	minitwit_api_latest_execution_time_in_ns = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:				 "minitwit_api_latest_execution_time_in_ns",
+		Help:				 "Histogram of the execution time of the latest middleware of the backend API ",
+		Buckets:		 []float64{1,10,100,1000,10000,100000,1000000,10000000,100000000,1000000000,10000000000},
+	})
+	minitwit_api_register_execution_time_in_ns = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:				 "minitwit_api_register_execution_time_in_ns",
+		Help:				 "Histogram of the execution time of the RegisterApiHandler of the backend API ",
+		Buckets:		 []float64{1,10,100,1000,10000,100000,1000000,10000000,100000000,1000000000,10000000000},
+	})
+	minitwit_api_messages_execution_time_in_ns = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:				 "minitwit_api_messages_execution_time_in_ns",
+		Help:				 "Histogram of the execution time of the MessagesHandler of the backend API ",
+		Buckets:		 []float64{1,10,100,1000,10000,100000,1000000,10000000,100000000,1000000000,10000000000},
+	})
+	minitwit_api_messages_per_user_execution_time_in_ns = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:				 "minitwit_api_messages_per_user_execution_time_in_ns",
+		Help:				 "Histogram of the execution time of the MessagesPerUserHandler of the backend API ",
+		Buckets:		 []float64{1,10,100,1000,10000,100000,1000000,10000000,100000000,1000000000,10000000000},
+	})
+	minitwit_api_follow_execution_time_in_ns = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:				 "minitwit_api_follow_execution_time_in_ns",
+		Help:				 "Histogram of the execution time of the FollowHandler of the backend API ",
+		Buckets:		 []float64{1,10,100,1000,10000,100000,1000000,10000000,100000000,1000000000,10000000000},
+	})
+	minitwit_api_authentication_middleware_execution_time_in_ns = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:				 "minitwit_api_authentication_middleware_execution_time_in_ns",
+		Help:				 "Histogram of the execution time of the AuthenticationMiddleware of the backend API ",
+		Buckets:		 []float64{1,10,100,1000,10000,100000,1000000,10000000,100000000,1000000000,10000000000},
+	})
+	minitwit_api_latest_middleware_execution_time_in_ns = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:				 "minitwit_api_latest_middleware_execution_time_in_ns",
+		Help:				 "Histogram of the execution time of the LatestMiddleware of the backend API ",
+		Buckets:		 []float64{1,10,100,1000,10000,100000,1000000,10000000,100000000,1000000000,10000000000},
+	})
+
 )
+
 
 
 func LatestHandler(db *gorm.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var t0 = time.Now()
 
 		latestObj, _ := GetLatest(db)
 		json.NewEncoder(w).Encode(&latestObj)
+
+		var elapsed = float64((time.Now().Sub(t0)).Nanoseconds())
+		minitwit_api_latest_execution_time_in_ns.Observe(elapsed)
+
 	})
 }
 
 func RegisterApiHandler(db *gorm.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
+		var t0 = time.Now()
 		minitwit_api_register_requests.Inc()
 
 		var u User_
@@ -59,6 +101,8 @@ func RegisterApiHandler(db *gorm.DB) http.Handler {
 
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
+			var elapsed = float64((time.Now().Sub(t0)).Nanoseconds())
+			minitwit_api_register_execution_time_in_ns.Observe(elapsed)
 			return
 		}
 
@@ -80,6 +124,8 @@ func RegisterApiHandler(db *gorm.DB) http.Handler {
 
 			w.WriteHeader(http.StatusBadRequest)
 			json.NewEncoder(w).Encode(&e)
+			var elapsed = float64((time.Now().Sub(t0)).Nanoseconds())
+			minitwit_api_register_execution_time_in_ns.Observe(elapsed)
 			return
 		}
 
@@ -100,12 +146,14 @@ func RegisterApiHandler(db *gorm.DB) http.Handler {
 
 		w.WriteHeader(http.StatusNoContent)
 		json.NewEncoder(w).Encode(&e)
+		var elapsed = float64((time.Now().Sub(t0)).Nanoseconds())
+		minitwit_api_register_execution_time_in_ns.Observe(elapsed)
 	})
 }
 
 func MessagesHandler(db *gorm.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
+		var t0 = time.Now();
 		minitwit_api_messages_requests.Inc()
 
 		//TODO: Update latest value?? Or does the middleware handle that?
@@ -157,6 +205,8 @@ func MessagesHandler(db *gorm.DB) http.Handler {
 			}
 
 			json.NewEncoder(w).Encode(&filteredMessages)
+			var elapsed = float64((time.Now().Sub(t0)).Nanoseconds())
+			minitwit_api_messages_execution_time_in_ns.Observe(elapsed)
 			return
 		}
 	})
@@ -164,6 +214,7 @@ func MessagesHandler(db *gorm.DB) http.Handler {
 
 func MessagesPerUserHandler(db *gorm.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var t0 = time.Now();
 
 		minitwit_api_messages_per_user_requests.Inc()
 
@@ -183,6 +234,8 @@ func MessagesPerUserHandler(db *gorm.DB) http.Handler {
 			user, err := GetUserByUsername(username, db)
 			if err != nil {
 				http.Error(w, "User not found", http.StatusNotFound)
+				var elapsed = float64((time.Now().Sub(t0)).Nanoseconds())
+				minitwit_api_messages_per_user_execution_time_in_ns.Observe(elapsed)
 				return
 			}
 
@@ -224,6 +277,8 @@ func MessagesPerUserHandler(db *gorm.DB) http.Handler {
 			}
 
 			json.NewEncoder(w).Encode(&filteredMessages)
+			var elapsed = float64((time.Now().Sub(t0)).Nanoseconds())
+			minitwit_api_messages_per_user_execution_time_in_ns.Observe(elapsed)
 			return
 		} else if r.Method == "POST" {
 			var msg Message_
@@ -231,6 +286,8 @@ func MessagesPerUserHandler(db *gorm.DB) http.Handler {
 
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusBadRequest)
+				var elapsed = float64((time.Now().Sub(t0)).Nanoseconds())
+				minitwit_api_messages_per_user_execution_time_in_ns.Observe(elapsed)
 				return
 			}
 
@@ -238,6 +295,8 @@ func MessagesPerUserHandler(db *gorm.DB) http.Handler {
 			user, err := GetUserByUsername(username, db)
 			if err != nil {
 				http.Error(w, "User not found", http.StatusNotFound)
+				var elapsed = float64((time.Now().Sub(t0)).Nanoseconds())
+				minitwit_api_messages_per_user_execution_time_in_ns.Observe(elapsed)
 				return
 			}
 
@@ -261,12 +320,16 @@ func MessagesPerUserHandler(db *gorm.DB) http.Handler {
 func FollowHandler(db *gorm.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
+		var t0 = time.Now()
+
 		minitwit_api_follow_requests.Inc()
 
 		username := mux.Vars(r)["username"]
 		user, err := GetUserByUsername(username, db)
 		if err != nil {
 			http.Error(w, "User not found", http.StatusNotFound)
+			var elapsed = float64((time.Now().Sub(t0)).Nanoseconds())
+			minitwit_api_follow_execution_time_in_ns.Observe(elapsed)
 			return
 		}
 
@@ -280,6 +343,8 @@ func FollowHandler(db *gorm.DB) http.Handler {
 			userToFollow, err := GetUserByUsername(requestBody.Follow, db)
 			if err != nil {
 				http.Error(w, "User not found", http.StatusNotFound)
+				var elapsed = float64((time.Now().Sub(t0)).Nanoseconds())
+				minitwit_api_follow_execution_time_in_ns.Observe(elapsed)
 				return
 			}
 
@@ -293,11 +358,15 @@ func FollowHandler(db *gorm.DB) http.Handler {
 			}
 
 			w.WriteHeader(http.StatusNoContent)
+			var elapsed = float64((time.Now().Sub(t0)).Nanoseconds())
+			minitwit_api_follow_execution_time_in_ns.Observe(elapsed)
 			return
 		} else if r.Method == "POST" && requestBody.Unfollow != "" {
 			userToUnfollow, err := GetUserByUsername(requestBody.Unfollow, db)
 			if err != nil {
 				http.Error(w, "User not found", http.StatusNotFound)
+				var elapsed = float64((time.Now().Sub(t0)).Nanoseconds())
+				minitwit_api_follow_execution_time_in_ns.Observe(elapsed)
 				return
 			}
 
@@ -311,6 +380,8 @@ func FollowHandler(db *gorm.DB) http.Handler {
 			}
 
 			w.WriteHeader(http.StatusNoContent)
+			var elapsed = float64((time.Now().Sub(t0)).Nanoseconds())
+			minitwit_api_follow_execution_time_in_ns.Observe(elapsed)
 			return
 		} else if r.Method == "GET" {
 			numberOfFollowersHeaderResult := r.URL.Query().Get("no")
@@ -341,6 +412,8 @@ func FollowHandler(db *gorm.DB) http.Handler {
 			}
 			followersResponse := response{Follows: followers}
 			json.NewEncoder(w).Encode(&followersResponse)
+			var elapsed = float64((time.Now().Sub(t0)).Nanoseconds())
+			minitwit_api_follow_execution_time_in_ns.Observe(elapsed)
 			return
 		}
 	})
@@ -348,6 +421,7 @@ func FollowHandler(db *gorm.DB) http.Handler {
 
 func AuthenticationMiddleware() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
+		var t0 = time.Now()
 		minitwit_api_total_requests.Inc()
 		mdfn := func(w http.ResponseWriter, r *http.Request) {
 			header := r.Header.Get("Authorization")
@@ -358,19 +432,25 @@ func AuthenticationMiddleware() func(http.Handler) http.Handler {
 				}
 				w.WriteHeader(http.StatusForbidden)
 				json.NewEncoder(w).Encode(&response)
+				var elapsed = float64((time.Now().Sub(t0)).Nanoseconds())
+				minitwit_api_authentication_middleware_execution_time_in_ns.Observe(elapsed)
 				return
 			}
 
 			next.ServeHTTP(w, r)
 		}
-
+		var elapsed = float64((time.Now().Sub(t0)).Nanoseconds())
+		minitwit_api_authentication_middleware_execution_time_in_ns.Observe(elapsed)
 		return http.HandlerFunc(mdfn)
 	}
 }
 
 func LatestMiddleware(db *gorm.DB) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
+		var t0 = time.Now()
+
 		mdfn := func(w http.ResponseWriter, r *http.Request) {
+
 
 			//If the request comes from Prometheus, skip the latestmiddleware
 			agent := r.Header.Get("User-Agent")
@@ -393,7 +473,8 @@ func LatestMiddleware(db *gorm.DB) func(http.Handler) http.Handler {
 
 			next.ServeHTTP(w, r)
 		}
-
+		var elapsed = float64((time.Now().Sub(t0)).Nanoseconds())
+		minitwit_api_latest_middleware_execution_time_in_ns.Observe(elapsed)
 		return http.HandlerFunc(mdfn)
 	}
 }

--- a/itu-minitwit-api/minitwit-api.go
+++ b/itu-minitwit-api/minitwit-api.go
@@ -75,7 +75,15 @@ func init() {
 	prometheus.MustRegister(minitwit_api_messages_per_user_requests)
 	prometheus.MustRegister(minitwit_api_follow_requests)
 	prometheus.MustRegister(minitwit_api_total_requests)
+	prometheus.MustRegister(minitwit_api_latest_execution_time_in_ns)
+	prometheus.MustRegister(minitwit_api_register_execution_time_in_ns)
+	prometheus.MustRegister(minitwit_api_messages_execution_time_in_ns)
+	prometheus.MustRegister(minitwit_api_messages_per_user_execution_time_in_ns)
+	prometheus.MustRegister(minitwit_api_follow_execution_time_in_ns)
+	prometheus.MustRegister(minitwit_api_authentication_middleware_execution_time_in_ns)
+	prometheus.MustRegister(minitwit_api_latest_middleware_execution_time_in_ns)
 }
+
 
 func main() {
 


### PR DESCRIPTION
All of the functions in the minitwit-api handlers.go file are now instrumented with Prometheus histograms.

Additionally, it should now be possible to persist Grafana dashboards between deploy if we do a 
`docker volume create grafana-storage`
on the droplet